### PR TITLE
Removed php warning in login/callback functions

### DIFF
--- a/code/GoogleAuthenticatorController.php
+++ b/code/GoogleAuthenticatorController.php
@@ -7,7 +7,7 @@ class GoogleAuthenticatorController extends Controller {
 	);
 
 	public function callback() {
-		$redirectUri = 'http' . ($_SERVER['HTTPS'] ? 's' : '') . '://' . $_SERVER['HTTP_HOST'] . '/GoogleAuthenticatorController/callback';
+		$redirectUri = 'http' . (isset($_SERVER['HTTPS']) ? ($_SERVER['HTTPS'] ? 's' : '') : '') . '://' . $_SERVER['HTTP_HOST'] . '/GoogleAuthenticatorController/callback';
 
 		$client = new Google_Client();
 		$client->setClientId(GOOGLE_AUTHENTICATOR_CLIENT_ID);

--- a/code/GoogleAuthenticatorLoginForm.php
+++ b/code/GoogleAuthenticatorLoginForm.php
@@ -63,7 +63,7 @@ class GoogleAuthenticatorLoginForm extends MemberLoginForm {
 	 * after the Google authentication
 	 */
 	public function dologin($data) {
-		$redirectUri = 'http' . ($_SERVER['HTTPS'] ? 's' : '') . '://' . $_SERVER['HTTP_HOST'] . '/GoogleAuthenticatorController/callback';
+		$redirectUri = 'http' . (isset($_SERVER['HTTPS']) ? ($_SERVER['HTTPS'] ? 's' : '') : '') . '://' . $_SERVER['HTTP_HOST'] . '/GoogleAuthenticatorController/callback';
 
 		$client = new Google_Client();
 		$client->setClientId(GOOGLE_AUTHENTICATOR_CLIENT_ID);


### PR DESCRIPTION
Removed php warning in login/callback functions when $_SERVER['HTTPS'] was not set. This occurs only in environments where warnings are outputted to the browser
